### PR TITLE
feat: trigger dtls release sync on asimonim release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,3 +173,16 @@ jobs:
             --repo zed-industries/extensions \
             --title "Update design-tokens to v${{ steps.version.outputs.version }}" \
             --body "Updates design-tokens extension to [version ${{ steps.version.outputs.version }}](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }})."
+
+  sync-dtls:
+    name: Sync DTLS Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger DTLS sync
+        env:
+          GH_TOKEN: ${{ secrets.DTLS_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run sync-asimonim.yaml \
+            --repo bennypowers/design-tokens-language-server \
+            --field asimonim_version=${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

Adds a `sync-dtls` job to the release workflow that triggers a `workflow_dispatch` on `bennypowers/design-tokens-language-server` after a successful build. This updates dtls's asimonim dependency and creates a matching release automatically.

### Required secret

- `DTLS_DISPATCH_TOKEN` — PAT with `actions:write` scope on the dtls repo

### Companion PR

- bennypowers/design-tokens-language-server#82 — adds the `sync-asimonim.yaml` workflow that receives the dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to automate synchronization processes during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->