### PR TITLE
feat(lsp): inlay hints for design token values

### DIFF
--- a/lsp/methods/lifecycle/initialize.go
+++ b/lsp/methods/lifecycle/initialize.go
@@ -66,6 +66,7 @@ func Initialize(req *types.RequestContext, params *protocol.InitializeParams) (a
 		ResolveProvider: boolPtr(true),
 	}
 	capabilities.ColorProvider = true
+	capabilities.InlayHintProvider = true
 	capabilities.SemanticTokensProvider = protocol.SemanticTokensOptions{
 		Legend: protocol.SemanticTokensLegend{
 			TokenTypes:     []string{"class", "property"},

--- a/lsp/methods/textDocument/inlayHint/inlayHint.go
+++ b/lsp/methods/textDocument/inlayHint/inlayHint.go
@@ -54,7 +54,7 @@ func hintForVarCall(req *types.RequestContext, requestRange protocol.Range, varC
 		return zero, false
 	}
 
-	if !varCallInRange(varCall, requestRange) {
+	if !hintPositionInRange(varCall, requestRange) {
 		return zero, false
 	}
 
@@ -77,17 +77,17 @@ func hintForVarCall(req *types.RequestContext, requestRange protocol.Range, varC
 	}, true
 }
 
-func varCallInRange(varCall *css.VarCall, r protocol.Range) bool {
-	if varCall.Range.End.Line < r.Start.Line {
+func hintPositionInRange(varCall *css.VarCall, r protocol.Range) bool {
+	line := varCall.Range.End.Line
+	char := varCall.Range.End.Character - 1
+
+	if line < r.Start.Line || line > r.End.Line {
 		return false
 	}
-	if varCall.Range.Start.Line > r.End.Line {
+	if line == r.Start.Line && char < r.Start.Character {
 		return false
 	}
-	if varCall.Range.End.Line == r.Start.Line && varCall.Range.End.Character < r.Start.Character {
-		return false
-	}
-	if varCall.Range.Start.Line == r.End.Line && varCall.Range.Start.Character > r.End.Character {
+	if line == r.End.Line && char >= r.End.Character {
 		return false
 	}
 	return true

--- a/lsp/methods/textDocument/inlayHint/inlayHint.go
+++ b/lsp/methods/textDocument/inlayHint/inlayHint.go
@@ -1,0 +1,96 @@
+package inlayhint
+
+import (
+	"fmt"
+
+	"bennypowers.dev/asimonim/lsp/internal/log"
+	"bennypowers.dev/asimonim/lsp/internal/parser"
+	"bennypowers.dev/asimonim/lsp/internal/parser/css"
+	"bennypowers.dev/asimonim/lsp/types"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+)
+
+// InlayHint handles the textDocument/inlayHint request.
+// Returns resolved token values as inlay hints next to var() calls.
+func InlayHint(req *types.RequestContext, params *protocol.InlayHintParams) ([]protocol.InlayHint, error) {
+	if !req.Server.InlayHintsEnabled() {
+		return nil, nil
+	}
+
+	uri := params.TextDocument.URI
+	log.Info("InlayHint requested: %s", uri)
+
+	doc := req.Server.Document(uri)
+	if doc == nil {
+		return nil, nil
+	}
+
+	if !parser.IsCSSSupportedLanguage(doc.LanguageID()) {
+		return nil, nil
+	}
+
+	result, err := parser.ParseCSSFromDocument(doc.Content(), doc.LanguageID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CSS: %w", err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	var hints []protocol.InlayHint
+	for _, varCall := range result.VarCalls {
+		if hint, ok := hintForVarCall(req, params.Range, varCall); ok {
+			hints = append(hints, hint)
+		}
+	}
+
+	return hints, nil
+}
+
+func hintForVarCall(req *types.RequestContext, requestRange protocol.Range, varCall *css.VarCall) (protocol.InlayHint, bool) {
+	var zero protocol.InlayHint
+
+	if varCall.Fallback != nil {
+		return zero, false
+	}
+
+	if !varCallInRange(varCall, requestRange) {
+		return zero, false
+	}
+
+	token := req.Server.Token(varCall.TokenName)
+	if token == nil {
+		return zero, false
+	}
+
+	displayValue := token.DisplayValue()
+	if displayValue == "" {
+		return zero, false
+	}
+
+	padLeft := true
+	return protocol.InlayHint{
+		Position: protocol.Position{
+			Line:      varCall.Range.End.Line,
+			Character: varCall.Range.End.Character - 1,
+		},
+		Label:       ", " + displayValue,
+		PaddingLeft: &padLeft,
+	}, true
+}
+
+func varCallInRange(varCall *css.VarCall, r protocol.Range) bool {
+	if varCall.Range.End.Line < r.Start.Line {
+		return false
+	}
+	if varCall.Range.Start.Line > r.End.Line {
+		return false
+	}
+	if varCall.Range.End.Line == r.Start.Line && varCall.Range.End.Character < r.Start.Character {
+		return false
+	}
+	if varCall.Range.Start.Line == r.End.Line && varCall.Range.Start.Character > r.End.Character {
+		return false
+	}
+	return true
+}

--- a/lsp/methods/textDocument/inlayHint/inlayHint.go
+++ b/lsp/methods/textDocument/inlayHint/inlayHint.go
@@ -68,14 +68,12 @@ func hintForVarCall(req *types.RequestContext, requestRange protocol.Range, varC
 		return zero, false
 	}
 
-	padLeft := true
 	return protocol.InlayHint{
 		Position: protocol.Position{
 			Line:      varCall.Range.End.Line,
 			Character: varCall.Range.End.Character - 1,
 		},
-		Label:       ", " + displayValue,
-		PaddingLeft: &padLeft,
+		Label: ", " + displayValue,
 	}, true
 }
 

--- a/lsp/methods/textDocument/inlayHint/inlayHint_test.go
+++ b/lsp/methods/textDocument/inlayHint/inlayHint_test.go
@@ -1,0 +1,346 @@
+package inlayhint
+
+import (
+	"testing"
+
+	"bennypowers.dev/asimonim/lsp/internal/tokens"
+	"bennypowers.dev/asimonim/lsp/testutil"
+	"bennypowers.dev/asimonim/lsp/types"
+	"github.com/bennypowers/glsp"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInlayHint_VarCallShowsResolvedValue(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.lg",
+		Value: "24px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.css"
+	// padding: var(--spacing-lg);
+	cssContent := `.box { padding: var(--spacing-lg); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	// Hint positioned before closing paren of var()
+	// `.box { padding: var(--spacing-lg); }`
+	//                                   ^ position 32 (before closing paren)
+	assert.Equal(t, uint32(0), result[0].Position.Line)
+	assert.Equal(t, uint32(32), result[0].Position.Character)
+	// Label is ", 24px" to look like a fallback value
+	assert.Equal(t, ", 24px", result[0].Label)
+	padLeft := true
+	assert.Equal(t, &padLeft, result[0].PaddingLeft)
+}
+
+func TestInlayHint_UnknownTokenSkipped(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	uri := "file:///test.css"
+	cssContent := `.box { padding: var(--unknown-token); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestInlayHint_EmptyDocument(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	uri := "file:///test.css"
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, ""))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 0},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestInlayHint_DisabledBySetting(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	disabled := false
+	cfg := ctx.GetConfig()
+	cfg.InlayHints = &disabled
+	ctx.SetConfig(cfg)
+
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.lg",
+		Value: "24px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.css"
+	cssContent := `.box { padding: var(--spacing-lg); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestInlayHint_VarCallWithExistingFallback(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.lg",
+		Value: "24px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.css"
+	// var() already has a fallback - no hint needed
+	cssContent := `.box { padding: var(--spacing-lg, 16px); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestInlayHint_MultipleVarCalls(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.sm",
+		Value: "8px",
+		Type:  "dimension",
+	}))
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.lg",
+		Value: "24px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.css"
+	cssContent := `.box {
+  padding: var(--spacing-sm);
+  margin: var(--spacing-lg);
+}`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 3, Character: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+}
+
+func TestInlayHint_ColorToken(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "color.primary",
+		Value: "#ff0000",
+		Type:  "color",
+	}))
+
+	uri := "file:///test.css"
+	cssContent := `.btn { color: var(--color-primary); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	// color.primary DisplayValue = "#ff0000"
+	assert.Equal(t, ", #ff0000", result[0].Label)
+}
+
+func TestInlayHint_HTMLDocument(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.lg",
+		Value: "24px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.html"
+	htmlContent := `<style>.box { padding: var(--spacing-lg); }</style>`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "html", 1, htmlContent))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, ", 24px", result[0].Label)
+}
+
+func TestInlayHint_MissingDocument(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: "file:///nonexistent.css"},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 0},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestInlayHint_VarCallOutsideRange(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.sm",
+		Value: "8px",
+		Type:  "dimension",
+	}))
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.lg",
+		Value: "24px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.css"
+	cssContent := `.a { padding: var(--spacing-sm); }
+.b { margin: var(--spacing-lg); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	// Request only line 1 -- should exclude line 0 var() call
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 1, Character: 0},
+			End:   protocol.Position{Line: 1, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	// spacing.lg on line 1, not spacing.sm on line 0
+	assert.Equal(t, ", 24px", result[0].Label)
+	assert.Equal(t, uint32(1), result[0].Position.Line)
+}
+
+func TestInlayHint_RangeExcludesBothLines(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
+		Name:  "spacing.sm",
+		Value: "8px",
+		Type:  "dimension",
+	}))
+
+	uri := "file:///test.css"
+	cssContent := `.a { padding: var(--spacing-sm); }`
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
+
+	// Request range on a different line entirely
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 5, Character: 0},
+			End:   protocol.Position{Line: 10, Character: 0},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestInlayHint_UnsupportedLanguage(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	uri := "file:///test.json"
+	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "json", 1, `{"foo": "bar"}`))
+
+	result, err := InlayHint(req, &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 100},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/lsp/methods/textDocument/inlayHint/inlayHint_test.go
+++ b/lsp/methods/textDocument/inlayHint/inlayHint_test.go
@@ -6,6 +6,8 @@ import (
 	"bennypowers.dev/asimonim/lsp/internal/tokens"
 	"bennypowers.dev/asimonim/lsp/testutil"
 	"bennypowers.dev/asimonim/lsp/types"
+	"bennypowers.dev/asimonim/schema"
+	fixtureutil "bennypowers.dev/asimonim/testutil"
 	"github.com/bennypowers/glsp"
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 	"github.com/stretchr/testify/assert"
@@ -13,19 +15,18 @@ import (
 )
 
 func TestInlayHint_VarCallShowsResolvedValue(t *testing.T) {
+	allTokens := fixtureutil.ParseFixtureTokens(t, "fixtures/v2025_10/all-color-spaces", schema.V2025_10)
+	// spacing.small: {value: 4, unit: "px"} -> 4px
+	spacingSmall := fixtureutil.TokenByPath(t, allTokens, "spacing.small")
+
 	ctx := testutil.NewMockServerContext()
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
-
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "spacing.lg",
-		Value: "24px",
-		Type:  "dimension",
-	}))
+	require.NoError(t, ctx.TokenManager().Add(spacingSmall))
 
 	uri := "file:///test.css"
-	// padding: var(--spacing-lg);
-	cssContent := `.box { padding: var(--spacing-lg); }`
+	// `.box { padding: var(--spacing-small); }`
+	cssContent := `.box { padding: var(--spacing-small); }`
 	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
 
 	result, err := InlayHint(req, &protocol.InlayHintParams{
@@ -40,14 +41,12 @@ func TestInlayHint_VarCallShowsResolvedValue(t *testing.T) {
 	require.Len(t, result, 1)
 
 	// Hint positioned before closing paren of var()
-	// `.box { padding: var(--spacing-lg); }`
-	//                                   ^ position 32 (before closing paren)
+	// `.box { padding: var(--spacing-small); }`
+	//                                      ^ position 35 (before closing paren)
 	assert.Equal(t, uint32(0), result[0].Position.Line)
-	assert.Equal(t, uint32(32), result[0].Position.Character)
-	// Label is ", 24px" to look like a fallback value
-	assert.Equal(t, ", 24px", result[0].Label)
-	padLeft := true
-	assert.Equal(t, &padLeft, result[0].PaddingLeft)
+	assert.Equal(t, uint32(35), result[0].Position.Character)
+	// spacing.small DisplayValue = "4px"
+	assert.Equal(t, ", 4px", result[0].Label)
 }
 
 func TestInlayHint_UnknownTokenSkipped(t *testing.T) {
@@ -92,6 +91,9 @@ func TestInlayHint_EmptyDocument(t *testing.T) {
 }
 
 func TestInlayHint_DisabledBySetting(t *testing.T) {
+	allTokens := fixtureutil.ParseFixtureTokens(t, "fixtures/v2025_10/all-color-spaces", schema.V2025_10)
+	spacingSmall := fixtureutil.TokenByPath(t, allTokens, "spacing.small")
+
 	ctx := testutil.NewMockServerContext()
 	disabled := false
 	cfg := ctx.GetConfig()
@@ -100,15 +102,10 @@ func TestInlayHint_DisabledBySetting(t *testing.T) {
 
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
-
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "spacing.lg",
-		Value: "24px",
-		Type:  "dimension",
-	}))
+	require.NoError(t, ctx.TokenManager().Add(spacingSmall))
 
 	uri := "file:///test.css"
-	cssContent := `.box { padding: var(--spacing-lg); }`
+	cssContent := `.box { padding: var(--spacing-small); }`
 	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
 
 	result, err := InlayHint(req, &protocol.InlayHintParams{
@@ -124,19 +121,16 @@ func TestInlayHint_DisabledBySetting(t *testing.T) {
 }
 
 func TestInlayHint_VarCallWithExistingFallback(t *testing.T) {
+	allTokens := fixtureutil.ParseFixtureTokens(t, "fixtures/v2025_10/all-color-spaces", schema.V2025_10)
+	spacingSmall := fixtureutil.TokenByPath(t, allTokens, "spacing.small")
+
 	ctx := testutil.NewMockServerContext()
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
-
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "spacing.lg",
-		Value: "24px",
-		Type:  "dimension",
-	}))
+	require.NoError(t, ctx.TokenManager().Add(spacingSmall))
 
 	uri := "file:///test.css"
-	// var() already has a fallback - no hint needed
-	cssContent := `.box { padding: var(--spacing-lg, 16px); }`
+	cssContent := `.box { padding: var(--spacing-small, 16px); }`
 	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
 
 	result, err := InlayHint(req, &protocol.InlayHintParams{
@@ -152,25 +146,22 @@ func TestInlayHint_VarCallWithExistingFallback(t *testing.T) {
 }
 
 func TestInlayHint_MultipleVarCalls(t *testing.T) {
+	allTokens := fixtureutil.ParseFixtureTokens(t, "fixtures/v2025_10/all-color-spaces", schema.V2025_10)
+	// spacing.small: {value: 4, unit: "px"} -> 4px
+	spacingSmall := fixtureutil.TokenByPath(t, allTokens, "spacing.small")
+	// spacing.medium: {value: 1.5, unit: "rem"} -> 1.5rem
+	spacingMedium := fixtureutil.TokenByPath(t, allTokens, "spacing.medium")
+
 	ctx := testutil.NewMockServerContext()
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
-
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "spacing.sm",
-		Value: "8px",
-		Type:  "dimension",
-	}))
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "spacing.lg",
-		Value: "24px",
-		Type:  "dimension",
-	}))
+	require.NoError(t, ctx.TokenManager().Add(spacingSmall))
+	require.NoError(t, ctx.TokenManager().Add(spacingMedium))
 
 	uri := "file:///test.css"
 	cssContent := `.box {
-  padding: var(--spacing-sm);
-  margin: var(--spacing-lg);
+  padding: var(--spacing-small);
+  margin: var(--spacing-medium);
 }`
 	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
 
@@ -184,21 +175,27 @@ func TestInlayHint_MultipleVarCalls(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, result, 2)
+
+	// spacing.small on line 1: ", 4px"
+	assert.Equal(t, uint32(1), result[0].Position.Line)
+	assert.Equal(t, ", 4px", result[0].Label)
+	// spacing.medium on line 2: ", 1.5rem"
+	assert.Equal(t, uint32(2), result[1].Position.Line)
+	assert.Equal(t, ", 1.5rem", result[1].Label)
 }
 
 func TestInlayHint_ColorToken(t *testing.T) {
+	allTokens := fixtureutil.ParseFixtureTokens(t, "fixtures/v2025_10/all-color-spaces", schema.V2025_10)
+	// color.srgb-hex: structured color -> DisplayValue = "#FF6B36"
+	colorHex := fixtureutil.TokenByPath(t, allTokens, "color.srgb-hex")
+
 	ctx := testutil.NewMockServerContext()
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
-
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "color.primary",
-		Value: "#ff0000",
-		Type:  "color",
-	}))
+	require.NoError(t, ctx.TokenManager().Add(colorHex))
 
 	uri := "file:///test.css"
-	cssContent := `.btn { color: var(--color-primary); }`
+	cssContent := `.btn { color: var(--color-srgb-hex); }`
 	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "css", 1, cssContent))
 
 	result, err := InlayHint(req, &protocol.InlayHintParams{
@@ -211,23 +208,22 @@ func TestInlayHint_ColorToken(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
-	// color.primary DisplayValue = "#ff0000"
-	assert.Equal(t, ", #ff0000", result[0].Label)
+	// color.srgb-hex DisplayValue = "#FF6B36"
+	assert.Equal(t, ", #FF6B36", result[0].Label)
 }
 
 func TestInlayHint_HTMLDocument(t *testing.T) {
+	allTokens := fixtureutil.ParseFixtureTokens(t, "fixtures/v2025_10/all-color-spaces", schema.V2025_10)
+	// spacing.small: {value: 4, unit: "px"} -> 4px
+	spacingSmall := fixtureutil.TokenByPath(t, allTokens, "spacing.small")
+
 	ctx := testutil.NewMockServerContext()
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
-
-	require.NoError(t, ctx.TokenManager().Add(&tokens.Token{
-		Name:  "spacing.lg",
-		Value: "24px",
-		Type:  "dimension",
-	}))
+	require.NoError(t, ctx.TokenManager().Add(spacingSmall))
 
 	uri := "file:///test.html"
-	htmlContent := `<style>.box { padding: var(--spacing-lg); }</style>`
+	htmlContent := `<style>.box { padding: var(--spacing-small); }</style>`
 	require.NoError(t, ctx.DocumentManager().DidOpen(uri, "html", 1, htmlContent))
 
 	result, err := InlayHint(req, &protocol.InlayHintParams{
@@ -240,7 +236,8 @@ func TestInlayHint_HTMLDocument(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
-	assert.Equal(t, ", 24px", result[0].Label)
+	// spacing.small DisplayValue = "4px"
+	assert.Equal(t, ", 4px", result[0].Label)
 }
 
 func TestInlayHint_MissingDocument(t *testing.T) {

--- a/lsp/middleware_test.go
+++ b/lsp/middleware_test.go
@@ -65,6 +65,7 @@ func (m *mockServerContext) ShouldProcessAsTokenFile(uri string) bool { return t
 func (m *mockServerContext) LoadTokensFromDocumentContent(uri, languageID, content string) error {
 	return nil
 }
+func (m *mockServerContext) InlayHintsEnabled() bool                      { return true }
 func (m *mockServerContext) Version() string                              { return "dev" }
 func (m *mockServerContext) SemanticTokenCache() types.SemanticTokenCacher {
 	if m.cache == nil {

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -20,6 +20,7 @@ import (
 	"bennypowers.dev/asimonim/lsp/methods/textDocument/diagnostic"
 	documentcolor "bennypowers.dev/asimonim/lsp/methods/textDocument/documentColor"
 	"bennypowers.dev/asimonim/lsp/methods/textDocument/hover"
+	inlayhint "bennypowers.dev/asimonim/lsp/methods/textDocument/inlayHint"
 	"bennypowers.dev/asimonim/lsp/methods/textDocument/references"
 	semantictokens "bennypowers.dev/asimonim/lsp/methods/textDocument/semanticTokens"
 	"bennypowers.dev/asimonim/lsp/methods/workspace"
@@ -100,6 +101,7 @@ func NewServer(opts ...Option) (*Server, error) {
 		},
 		Initialize:             method(s, "initialize", lifecycle.Initialize),
 		TextDocumentDiagnostic: method(s, "textDocument/diagnostic", diagnostic.DocumentDiagnostic),
+		TextDocumentInlayHint:  method(s, "textDocument/inlayHint", inlayhint.InlayHint),
 	}
 
 	customHandler := &CustomHandler{
@@ -240,6 +242,16 @@ func (s *Server) SetClientCapabilities(caps protocol.ClientCapabilities) {
 	s.configMu.Lock()
 	defer s.configMu.Unlock()
 	s.clientCapabilities = &caps
+}
+
+// InlayHintsEnabled returns whether inlay hints are enabled in config.
+func (s *Server) InlayHintsEnabled() bool {
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
+	if s.config.InlayHints == nil {
+		return true
+	}
+	return *s.config.InlayHints
 }
 
 // SupportsSnippets returns whether the client supports snippet completions.

--- a/lsp/testutil/mock.go
+++ b/lsp/testutil/mock.go
@@ -344,6 +344,14 @@ func (m *MockServerContext) SetSupportsCodeActionLiterals(supports bool) {
 	m.supportsCodeActionLiterals = &supports
 }
 
+// InlayHintsEnabled returns whether inlay hints are enabled in config.
+func (m *MockServerContext) InlayHintsEnabled() bool {
+	if m.config.InlayHints == nil {
+		return true
+	}
+	return *m.config.InlayHints
+}
+
 // PublishDiagnostics publishes diagnostics for a document
 func (m *MockServerContext) PublishDiagnostics(context *glsp.Context, uri string) error {
 	if m.PublishDiagnosticsFunc != nil {

--- a/lsp/types/config.go
+++ b/lsp/types/config.go
@@ -51,6 +51,10 @@ type ServerConfig struct {
 	// Valid values: "unpkg", "esm.sh", "esm.run", "jspm", "jsdelivr".
 	// Defaults to "unpkg" if empty. Has no effect if NetworkFallback is false.
 	CDN string `json:"cdn,omitempty"`
+
+	// InlayHints enables inlay hints showing resolved token values next to var() calls.
+	// Defaults to true.
+	InlayHints *bool `json:"inlayHints,omitempty"`
 }
 
 // ServerState represents a snapshot of runtime state (NOT configuration)
@@ -63,6 +67,7 @@ type ServerState struct {
 
 // DefaultConfig returns the default server configuration
 func DefaultConfig() ServerConfig {
+	inlayHints := true
 	return ServerConfig{
 		TokensFiles: nil, // No default tokens - must be explicitly configured
 		Prefix:      "",
@@ -74,5 +79,6 @@ func DefaultConfig() ServerConfig {
 		NetworkFallback: false,
 		NetworkTimeout:  0,
 		CDN:             "",
+		InlayHints:      &inlayHints,
 	}
 }

--- a/lsp/types/context.go
+++ b/lsp/types/context.go
@@ -60,6 +60,9 @@ type ServerContext interface {
 	ClientCapabilities() *protocol.ClientCapabilities
 	SetClientCapabilities(caps protocol.ClientCapabilities)
 
+	// InlayHintsEnabled returns whether inlay hints are enabled in config
+	InlayHintsEnabled() bool
+
 	// Capability helpers derived from ClientCapabilities
 	SupportsSnippets() bool
 	PreferredHoverFormat() protocol.MarkupKind

--- a/lsp/types/request_context_test.go
+++ b/lsp/types/request_context_test.go
@@ -106,6 +106,7 @@ func (m *mockServerContextMinimal) ShouldProcessAsTokenFile(uri string) bool { r
 func (m *mockServerContextMinimal) LoadTokensFromDocumentContent(uri, languageID, content string) error {
 	return nil
 }
+func (m *mockServerContextMinimal) InlayHintsEnabled() bool                { return true }
 func (m *mockServerContextMinimal) Version() string                        { return "dev" }
 func (m *mockServerContextMinimal) SemanticTokenCache() SemanticTokenCacher {
 	if m.cache == nil {


### PR DESCRIPTION
## Summary

- Add `textDocument/inlayHint` handler showing resolved token values next to `var()` calls
- Hints appear as `, <value>` to resemble CSS fallback syntax (e.g. `var(--spacing-lg, 24px)`)
- Works across CSS, HTML, JS/TS, PHP, and Twig
- Skips `var()` calls that already have a fallback value
- Skips unknown tokens (no hint rather than error)
- Add `inlayHints` setting (defaults to `true`) for toggling the feature off
- Advertise `InlayHintProvider` in server capabilities

Closes #43

## Test plan

- [x] 12 unit tests covering:
  - Happy path with dimension and color tokens
  - Position character accuracy (before closing paren)
  - Unknown token exclusion
  - Empty document handling
  - Setting disabled returns empty
  - Existing fallback values skipped
  - Multiple var() calls
  - HTML embedded CSS
  - Missing document
  - Unsupported language (JSON)
  - Range filtering (var call outside requested range)
  - Range filtering (completely disjoint range)
- [x] `make lint` passes
- [x] `make test` passes (full suite, zero regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor inlay hints now show resolved values for CSS variables in var() calls (CSS and embedded <style> in HTML). Hints appear just before the closing `)` and are negotiable during LSP initialization.
  * Inlay hints configurable via server setting and enabled by default.

* **Tests**
  * Added comprehensive tests covering multiple var() cases, ranges, document types, disabled setting, and missing/unknown tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->