### PR TITLE
feat(lsp): workspace diagnostics for batch token validation

### DIFF
--- a/lsp/methods/lifecycle/initialize.go
+++ b/lsp/methods/lifecycle/initialize.go
@@ -80,7 +80,7 @@ func Initialize(req *types.RequestContext, params *protocol.InitializeParams) (a
 	if supportsPullDiagnostics {
 		capabilities.DiagnosticProvider = protocol.DiagnosticOptions{
 			InterFileDependencies: false,
-			WorkspaceDiagnostics:  false,
+			WorkspaceDiagnostics:  true,
 		}
 	}
 

--- a/lsp/methods/lifecycle/initialize_test.go
+++ b/lsp/methods/lifecycle/initialize_test.go
@@ -107,6 +107,9 @@ func TestInitialize(t *testing.T) {
 		assert.NotNil(t, caps.ColorProvider)
 		assert.NotNil(t, caps.SemanticTokensProvider)
 		assert.NotNil(t, caps.DiagnosticProvider)
+		diagOpts, ok := caps.DiagnosticProvider.(protocol.DiagnosticOptions)
+		assert.True(t, ok)
+		assert.True(t, diagOpts.WorkspaceDiagnostics)
 
 		// Verify completion provider options
 		assert.NotNil(t, caps.CompletionProvider.ResolveProvider)

--- a/lsp/methods/lifecycle/initialize_test.go
+++ b/lsp/methods/lifecycle/initialize_test.go
@@ -108,7 +108,7 @@ func TestInitialize(t *testing.T) {
 		assert.NotNil(t, caps.SemanticTokensProvider)
 		assert.NotNil(t, caps.DiagnosticProvider)
 		diagOpts, ok := caps.DiagnosticProvider.(protocol.DiagnosticOptions)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.True(t, diagOpts.WorkspaceDiagnostics)
 
 		// Verify completion provider options

--- a/lsp/methods/workspace/diagnostic.go
+++ b/lsp/methods/workspace/diagnostic.go
@@ -1,0 +1,42 @@
+package workspace
+
+import (
+	"bennypowers.dev/asimonim/lsp/internal/log"
+	"bennypowers.dev/asimonim/lsp/methods/textDocument/diagnostic"
+	"bennypowers.dev/asimonim/lsp/types"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+)
+
+// WorkspaceDiagnostic handles the workspace/diagnostic request (LSP 3.17).
+// Returns diagnostics for all tracked documents in a single batch.
+func WorkspaceDiagnostic(req *types.RequestContext, params *protocol.WorkspaceDiagnosticParams) (*protocol.WorkspaceDiagnosticReport, error) {
+	log.Info("Workspace diagnostics requested")
+	return collectWorkspaceDiagnostics(req.Server, diagnostic.GetDiagnostics)
+}
+
+func collectWorkspaceDiagnostics(ctx types.ServerContext, getDiagnostics func(types.ServerContext, string) ([]protocol.Diagnostic, error)) (*protocol.WorkspaceDiagnosticReport, error) {
+	docs := ctx.AllDocuments()
+	items := make([]protocol.WorkspaceDocumentDiagnosticReport, 0, len(docs))
+
+	for _, doc := range docs {
+		diagnostics, err := getDiagnostics(ctx, doc.URI())
+		if err != nil {
+			log.Info("Warning: failed to get diagnostics for %s: %v", doc.URI(), err)
+			continue
+		}
+
+		version := protocol.Integer(doc.Version())
+		items = append(items, protocol.WorkspaceFullDocumentDiagnosticReport{
+			FullDocumentDiagnosticReport: protocol.FullDocumentDiagnosticReport{
+				Kind:  string(protocol.DocumentDiagnosticReportKindFull),
+				Items: diagnostics,
+			},
+			URI:     doc.URI(),
+			Version: &version,
+		})
+	}
+
+	return &protocol.WorkspaceDiagnosticReport{
+		Items: items,
+	}, nil
+}

--- a/lsp/methods/workspace/diagnosticRefresh.go
+++ b/lsp/methods/workspace/diagnosticRefresh.go
@@ -1,0 +1,17 @@
+package workspace
+
+import (
+	"bennypowers.dev/asimonim/lsp/internal/log"
+	"github.com/bennypowers/glsp"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+)
+
+// NotifyDiagnosticRefresh sends workspace/diagnostic/refresh to the client,
+// asking it to re-request diagnostics for all documents.
+func NotifyDiagnosticRefresh(ctx *glsp.Context) {
+	if ctx == nil || ctx.Notify == nil {
+		return
+	}
+	log.Info("Sending workspace/diagnostic/refresh")
+	ctx.Notify(protocol.MethodWorkspaceDiagnosticRefresh, nil)
+}

--- a/lsp/methods/workspace/diagnosticRefresh_test.go
+++ b/lsp/methods/workspace/diagnosticRefresh_test.go
@@ -1,0 +1,31 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/bennypowers/glsp"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotifyDiagnosticRefresh_NilContext(t *testing.T) {
+	// Should not panic
+	NotifyDiagnosticRefresh(nil)
+}
+
+func TestNotifyDiagnosticRefresh_NilNotify(t *testing.T) {
+	// Context with nil Notify should not panic
+	NotifyDiagnosticRefresh(&glsp.Context{})
+}
+
+func TestNotifyDiagnosticRefresh_SendsNotification(t *testing.T) {
+	var notifiedMethod string
+	ctx := &glsp.Context{
+		Notify: func(method string, params any) {
+			notifiedMethod = method
+		},
+	}
+
+	NotifyDiagnosticRefresh(ctx)
+	assert.Equal(t, protocol.MethodWorkspaceDiagnosticRefresh, notifiedMethod)
+}

--- a/lsp/methods/workspace/diagnostic_test.go
+++ b/lsp/methods/workspace/diagnostic_test.go
@@ -1,0 +1,182 @@
+package workspace
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"bennypowers.dev/asimonim/lsp/internal/tokens"
+	"bennypowers.dev/asimonim/lsp/testutil"
+	"bennypowers.dev/asimonim/lsp/types"
+	"github.com/bennypowers/glsp"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+// loadFixtureCSS reads a CSS fixture file from testdata/workspace-diagnostic/.
+func loadFixtureCSS(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "workspace-diagnostic", name))
+	require.NoError(t, err)
+	return string(data)
+}
+
+// goldenReport is a serializable subset of WorkspaceFullDocumentDiagnosticReport
+// for golden file comparison. Omits pointer fields that don't round-trip cleanly.
+type goldenReport struct {
+	URI         string                `json:"uri"`
+	Kind        string                `json:"kind"`
+	Version     int32                 `json:"version"`
+	Diagnostics []protocol.Diagnostic `json:"diagnostics"`
+}
+
+func TestWorkspaceDiagnostic_Golden(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	// color.old: deprecated token
+	_ = ctx.TokenManager().Add(&tokens.Token{
+		Name:               "color.old",
+		Value:              "#ff0000",
+		Type:               "color",
+		Deprecated:         true,
+		DeprecationMessage: "Use color.primary instead",
+	})
+	// color.primary: value is #0000ff, fixture uses wrong fallback #ff0000
+	_ = ctx.TokenManager().Add(&tokens.Token{
+		Name:  "color.primary",
+		Value: "#0000ff",
+		Type:  "color",
+	})
+
+	// Open documents from fixtures
+	_ = ctx.DocumentManager().DidOpen(
+		"file:///workspace/deprecated.css", "css", 1,
+		loadFixtureCSS(t, "deprecated.css"),
+	)
+	_ = ctx.DocumentManager().DidOpen(
+		"file:///workspace/wrong-fallback.css", "css", 2,
+		loadFixtureCSS(t, "wrong-fallback.css"),
+	)
+	_ = ctx.DocumentManager().DidOpen(
+		"file:///workspace/clean.css", "css", 3,
+		loadFixtureCSS(t, "clean.css"),
+	)
+
+	result, err := WorkspaceDiagnostic(req, &protocol.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Items, 3)
+
+	// Build sorted golden-comparable output
+	reports := make([]goldenReport, 0, len(result.Items))
+	for _, item := range result.Items {
+		report := item.(protocol.WorkspaceFullDocumentDiagnosticReport)
+		var ver int32
+		if report.Version != nil {
+			ver = *report.Version
+		}
+		reports = append(reports, goldenReport{
+			URI:         report.URI,
+			Kind:        report.Kind,
+			Version:     ver,
+			Diagnostics: report.Items,
+		})
+	}
+	sort.Slice(reports, func(i, j int) bool { return reports[i].URI < reports[j].URI })
+
+	actual, err := json.MarshalIndent(reports, "", "  ")
+	require.NoError(t, err)
+	actual = append(actual, '\n')
+
+	goldenPath := filepath.Join("testdata", "workspace-diagnostic", "golden.json")
+
+	if *update {
+		err := os.WriteFile(goldenPath, actual, 0644)
+		require.NoError(t, err)
+		t.Log("Updated golden file")
+		return
+	}
+
+	expected, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "Golden file missing; run with -update to create")
+
+	assert.JSONEq(t, string(expected), string(actual))
+}
+
+func TestWorkspaceDiagnostic_NoDocuments(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	result, err := WorkspaceDiagnostic(req, &protocol.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Items)
+}
+
+func TestWorkspaceDiagnostic_NonCSSDocumentsIncludedEmpty(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+	glspCtx := &glsp.Context{}
+	req := types.NewRequestContext(ctx, glspCtx)
+
+	_ = ctx.TokenManager().Add(&tokens.Token{
+		Name:       "color.old",
+		Value:      "#ff0000",
+		Type:       "color",
+		Deprecated: true,
+	})
+
+	_ = ctx.DocumentManager().DidOpen(
+		"file:///test.css", "css", 1,
+		loadFixtureCSS(t, "deprecated.css"),
+	)
+	_ = ctx.DocumentManager().DidOpen("file:///data.json", "json", 1, `{"test": true}`)
+
+	result, err := WorkspaceDiagnostic(req, &protocol.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 2)
+
+	reportsByURI := make(map[string]protocol.WorkspaceFullDocumentDiagnosticReport)
+	for _, item := range result.Items {
+		report := item.(protocol.WorkspaceFullDocumentDiagnosticReport)
+		reportsByURI[report.URI] = report
+	}
+
+	// CSS document: 1 diagnostic (deprecated)
+	assert.Len(t, reportsByURI["file:///test.css"].Items, 1)
+	// JSON document: 0 diagnostics (not CSS)
+	assert.Empty(t, reportsByURI["file:///data.json"].Items)
+}
+
+func TestCollectWorkspaceDiagnostics_SkipsOnError(t *testing.T) {
+	ctx := testutil.NewMockServerContext()
+
+	_ = ctx.DocumentManager().DidOpen("file:///ok.css", "css", 1, `.a { color: red; }`)
+	_ = ctx.DocumentManager().DidOpen("file:///bad.css", "css", 2, `.b { color: blue; }`)
+
+	// Injected diagnostics provider that errors for bad.css
+	failingFn := func(_ types.ServerContext, uri string) ([]protocol.Diagnostic, error) {
+		if uri == "file:///bad.css" {
+			return nil, fmt.Errorf("parse failure")
+		}
+		return []protocol.Diagnostic{}, nil
+	}
+
+	result, err := collectWorkspaceDiagnostics(ctx, failingFn)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// bad.css skipped, only ok.css in results
+	require.Len(t, result.Items, 1)
+	report := result.Items[0].(protocol.WorkspaceFullDocumentDiagnosticReport)
+	assert.Equal(t, "file:///ok.css", report.URI)
+}

--- a/lsp/methods/workspace/diagnostic_test.go
+++ b/lsp/methods/workspace/diagnostic_test.go
@@ -12,13 +12,21 @@ import (
 	"bennypowers.dev/asimonim/lsp/internal/tokens"
 	"bennypowers.dev/asimonim/lsp/testutil"
 	"bennypowers.dev/asimonim/lsp/types"
+	"bennypowers.dev/asimonim/schema"
+	rootutil "bennypowers.dev/asimonim/testutil"
 	"github.com/bennypowers/glsp"
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var update = flag.Bool("update", false, "update golden files")
+func shouldUpdate() bool {
+	f := flag.Lookup("update")
+	if f == nil {
+		return false
+	}
+	return f.Value.String() == "true"
+}
 
 // loadFixtureCSS reads a CSS fixture file from testdata/workspace-diagnostic/.
 func loadFixtureCSS(t *testing.T, name string) string {
@@ -42,20 +50,11 @@ func TestWorkspaceDiagnostic_Golden(t *testing.T) {
 	glspCtx := &glsp.Context{}
 	req := types.NewRequestContext(ctx, glspCtx)
 
-	// color.old: deprecated token
-	_ = ctx.TokenManager().Add(&tokens.Token{
-		Name:               "color.old",
-		Value:              "#ff0000",
-		Type:               "color",
-		Deprecated:         true,
-		DeprecationMessage: "Use color.primary instead",
-	})
-	// color.primary: value is #0000ff, fixture uses wrong fallback #ff0000
-	_ = ctx.TokenManager().Add(&tokens.Token{
-		Name:  "color.primary",
-		Value: "#0000ff",
-		Type:  "color",
-	})
+	// Load tokens from fixture (color.old: deprecated, color.primary: #0000ff)
+	fixtureTokens := rootutil.ParseFixtureTokens(t, "workspace-diagnostic", schema.Draft)
+	for _, tok := range fixtureTokens {
+		_ = ctx.TokenManager().Add(tok)
+	}
 
 	// Open documents from fixtures
 	_ = ctx.DocumentManager().DidOpen(
@@ -99,7 +98,7 @@ func TestWorkspaceDiagnostic_Golden(t *testing.T) {
 
 	goldenPath := filepath.Join("testdata", "workspace-diagnostic", "golden.json")
 
-	if *update {
+	if shouldUpdate() {
 		err := os.WriteFile(goldenPath, actual, 0644)
 		require.NoError(t, err)
 		t.Log("Updated golden file")

--- a/lsp/methods/workspace/didChangeConfiguration.go
+++ b/lsp/methods/workspace/didChangeConfiguration.go
@@ -30,14 +30,13 @@ func DidChangeConfiguration(req *types.RequestContext, params *protocol.DidChang
 		log.Info("Warning: failed to reload tokens: %v", err)
 	}
 
-	// Republish diagnostics for all open documents (only if using push model)
-	// If client supports pull diagnostics (LSP 3.17), it will request them via textDocument/diagnostic
-	if !req.Server.UsePullDiagnostics() {
-		if req.GLSP != nil {
-			for _, doc := range req.Server.AllDocuments() {
-				if err := req.Server.PublishDiagnostics(req.GLSP, doc.URI()); err != nil {
-					log.Info("Warning: failed to publish diagnostics for %s: %v", doc.URI(), err)
-				}
+	// Refresh diagnostics for all open documents
+	if req.Server.UsePullDiagnostics() {
+		NotifyDiagnosticRefresh(req.GLSP)
+	} else if req.GLSP != nil {
+		for _, doc := range req.Server.AllDocuments() {
+			if err := req.Server.PublishDiagnostics(req.GLSP, doc.URI()); err != nil {
+				log.Info("Warning: failed to publish diagnostics for %s: %v", doc.URI(), err)
 			}
 		}
 	}

--- a/lsp/methods/workspace/didChangeConfiguration_test.go
+++ b/lsp/methods/workspace/didChangeConfiguration_test.go
@@ -166,7 +166,14 @@ func TestDidChangeConfiguration_PublishesDiagnosticsForOpenDocs(t *testing.T) {
 
 func TestDidChangeConfiguration_SkipsDiagnosticsWithPullModel(t *testing.T) {
 	ctx := testutil.NewMockServerContext()
-	glspCtx := &glsp.Context{}
+
+	// Track refresh notification
+	var refreshMethod string
+	glspCtx := &glsp.Context{
+		Notify: func(method string, params any) {
+			refreshMethod = method
+		},
+	}
 	req := types.NewRequestContext(ctx, glspCtx)
 	ctx.SetGLSPContext(glspCtx)
 
@@ -198,6 +205,8 @@ func TestDidChangeConfiguration_SkipsDiagnosticsWithPullModel(t *testing.T) {
 
 	// Should NOT have published diagnostics
 	assert.False(t, publishCalled, "Should not publish diagnostics with pull model")
+	// Should have sent workspace/diagnostic/refresh
+	assert.Equal(t, protocol.MethodWorkspaceDiagnosticRefresh, refreshMethod)
 }
 
 func TestDidChangeConfiguration_WithGroupMarkers(t *testing.T) {

--- a/lsp/methods/workspace/didChangeWatchedFiles.go
+++ b/lsp/methods/workspace/didChangeWatchedFiles.go
@@ -52,9 +52,10 @@ func DidChangeWatchedFiles(req *types.RequestContext, params *protocol.DidChange
 			log.Info("Warning: failed to reload tokens: %v", err)
 		}
 
-		// Republish diagnostics for all open documents (only if using push model)
-		// If client supports pull diagnostics (LSP 3.17), it will request them via textDocument/diagnostic
-		if !req.Server.UsePullDiagnostics() {
+		// Refresh diagnostics for all open documents
+		if req.Server.UsePullDiagnostics() {
+			NotifyDiagnosticRefresh(req.GLSP)
+		} else {
 			glspCtx := req.Server.GLSPContext()
 			if glspCtx != nil {
 				for _, doc := range req.Server.AllDocuments() {

--- a/lsp/methods/workspace/didChangeWatchedFiles_test.go
+++ b/lsp/methods/workspace/didChangeWatchedFiles_test.go
@@ -7,6 +7,8 @@ import (
 	"bennypowers.dev/asimonim/lsp/types"
 	"github.com/bennypowers/glsp"
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleDidChangeWatchedFiles(t *testing.T) {
@@ -184,14 +186,19 @@ func TestHandleDidChangeWatchedFiles_NewlyCreatedFile(t *testing.T) {
 
 func TestHandleDidChangeWatchedFiles_SkipsDiagnosticsWithPullModel(t *testing.T) {
 	ctx := testutil.NewMockServerContext()
-	req := types.NewRequestContext(ctx, nil)
 	ctx.SetRootPath("/workspace")
 
 	// Enable pull diagnostics
 	ctx.SetUsePullDiagnostics(true)
 
-	// Set up GLSP context
-	glspCtx := &glsp.Context{}
+	// Track refresh notification
+	var refreshMethod string
+	glspCtx := &glsp.Context{
+		Notify: func(method string, params any) {
+			refreshMethod = method
+		},
+	}
+	req := types.NewRequestContext(ctx, glspCtx)
 	ctx.SetGLSPContext(glspCtx)
 
 	// Track PublishDiagnostics calls - should NOT be called
@@ -222,14 +229,12 @@ func TestHandleDidChangeWatchedFiles_SkipsDiagnosticsWithPullModel(t *testing.T)
 	}
 
 	err := DidChangeWatchedFiles(req, params)
-	if err != nil {
-		t.Errorf("DidChangeWatchedFiles failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Should NOT have published diagnostics because pull model is active
-	if publishCalled {
-		t.Error("Expected PublishDiagnostics NOT to be called with pull diagnostics enabled")
-	}
+	assert.False(t, publishCalled, "Should not publish diagnostics with pull model")
+	// Should have sent workspace/diagnostic/refresh
+	assert.Equal(t, protocol.MethodWorkspaceDiagnosticRefresh, refreshMethod)
 }
 
 func TestHandleDidChangeWatchedFiles_EmptyChanges(t *testing.T) {

--- a/lsp/methods/workspace/testdata/workspace-diagnostic/clean.css
+++ b/lsp/methods/workspace/testdata/workspace-diagnostic/clean.css
@@ -1,0 +1,4 @@
+.header {
+  color: blue;
+  margin: 0;
+}

--- a/lsp/methods/workspace/testdata/workspace-diagnostic/deprecated.css
+++ b/lsp/methods/workspace/testdata/workspace-diagnostic/deprecated.css
@@ -1,0 +1,3 @@
+.button {
+  color: var(--color-old);
+}

--- a/lsp/methods/workspace/testdata/workspace-diagnostic/golden.json
+++ b/lsp/methods/workspace/testdata/workspace-diagnostic/golden.json
@@ -1,0 +1,53 @@
+[
+  {
+    "uri": "file:///workspace/clean.css",
+    "kind": "full",
+    "version": 3,
+    "diagnostics": []
+  },
+  {
+    "uri": "file:///workspace/deprecated.css",
+    "kind": "full",
+    "version": 1,
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 9
+          },
+          "end": {
+            "line": 1,
+            "character": 25
+          }
+        },
+        "severity": 3,
+        "message": "--color-old is deprecated: Use color.primary instead",
+        "tags": [
+          2
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "file:///workspace/wrong-fallback.css",
+    "kind": "full",
+    "version": 2,
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 14
+          },
+          "end": {
+            "line": 1,
+            "character": 43
+          }
+        },
+        "severity": 1,
+        "message": "Token fallback does not match expected value: #0000ff"
+      }
+    ]
+  }
+]

--- a/lsp/methods/workspace/testdata/workspace-diagnostic/tokens.json
+++ b/lsp/methods/workspace/testdata/workspace-diagnostic/tokens.json
@@ -1,0 +1,13 @@
+{
+  "color": {
+    "old": {
+      "$value": "#ff0000",
+      "$type": "color",
+      "$deprecated": "Use color.primary instead"
+    },
+    "primary": {
+      "$value": "#0000ff",
+      "$type": "color"
+    }
+  }
+}

--- a/lsp/methods/workspace/testdata/workspace-diagnostic/wrong-fallback.css
+++ b/lsp/methods/workspace/testdata/workspace-diagnostic/wrong-fallback.css
@@ -1,0 +1,3 @@
+.card {
+  background: var(--color-primary, #ff0000);
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -102,6 +102,7 @@ func NewServer(opts ...Option) (*Server, error) {
 		Initialize:             method(s, "initialize", lifecycle.Initialize),
 		TextDocumentDiagnostic: method(s, "textDocument/diagnostic", diagnostic.DocumentDiagnostic),
 		TextDocumentInlayHint:  method(s, "textDocument/inlayHint", inlayhint.InlayHint),
+		WorkspaceDiagnostic:    method(s, "workspace/diagnostic", workspace.WorkspaceDiagnostic),
 	}
 
 	customHandler := &CustomHandler{


### PR DESCRIPTION
## Summary

- Add `workspace/diagnostic` handler (LSP 3.17) to validate all tracked documents in a single batch request, reusing `diagnostic.GetDiagnostics` per document
- Send `workspace/diagnostic/refresh` notification when token definitions change (config reload, watched file change) so clients re-request diagnostics
- Advertise `WorkspaceDiagnostics: true` in `DiagnosticOptions` capability

## Details

Previous behavior validated one file at a time via `textDocument/diagnostic`. Workspace diagnostics let the server report issues across all open files in one request, which is more efficient for initial workspace scan, token definition changes, and project-wide deprecated token usage views.

New files:
- `lsp/methods/workspace/diagnostic.go` -- workspace/diagnostic handler
- `lsp/methods/workspace/diagnosticRefresh.go` -- nil-safe refresh notification helper

Modified files:
- `lsp/methods/lifecycle/initialize.go` -- advertise workspace diagnostics capability
- `lsp/server.go` -- register handler
- `lsp/methods/workspace/didChangeConfiguration.go` -- send refresh on config change
- `lsp/methods/workspace/didChangeWatchedFiles.go` -- send refresh on file change

## Test plan

- [ ] Golden file test validates full workspace diagnostic response shape (deprecated, wrong fallback, clean)
- [ ] Error skip test verifies partial results when one document fails
- [ ] Empty workspace test verifies no-documents case
- [ ] Non-CSS documents included with empty diagnostics
- [ ] Refresh notification tests: nil context, nil Notify, correct method name
- [ ] Integration tests verify refresh sent in pull-diagnostics mode for both config change and file watch
- [ ] `WorkspaceDiagnostics: true` asserted in initialize test
- [ ] All new code at 100% coverage
- [ ] `make lint` and `make test` pass

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-level diagnostics support, enabling clients to request comprehensive diagnostics across all open documents
  * Improved diagnostic refresh notifications when configuration changes or watched files are modified
  * Enhanced language server capabilities to properly advertise workspace diagnostics features

* **Tests**
  * Added comprehensive test coverage for workspace diagnostics and refresh functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->