### PR TITLE
fix(mcp): discover config from MCP roots protocol

### DIFF
--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"bennypowers.dev/asimonim/config"
 	"bennypowers.dev/asimonim/fs"
 	"bennypowers.dev/asimonim/internal/logger"
 	mcpserver "bennypowers.dev/asimonim/mcp"
@@ -52,13 +51,12 @@ func run(cmd *cobra.Command, _ []string) error {
 	logger.SetOutput(io.Discard)
 
 	filesystem := fs.NewOSFileSystem()
-	cfg := config.LoadOrDefault(filesystem, ".")
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	server := mcpserver.NewServer(filesystem, cfg, cwd)
+	server := mcpserver.NewServer(filesystem, nil, cwd)
 	return server.Run(cmd.Context())
 }

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -53,6 +53,13 @@ func newTokenDetail(tok *token.Token) tokenDetail {
 	}
 }
 
+func sessionFromResourceReq(req *mcp.ReadResourceRequest) *mcp.ServerSession {
+	if req == nil {
+		return nil
+	}
+	return req.Session
+}
+
 func (s *Server) setupResources() {
 	// asimonim://tokens - list available token sources
 	s.server.AddResource(&mcp.Resource{
@@ -88,14 +95,15 @@ func (s *Server) setupResources() {
 }
 
 func (s *Server) handleTokenSources(
-	_ context.Context,
+	ctx context.Context,
 	req *mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
 	if err := validateResourceRequest(req); err != nil {
 		return nil, err
 	}
 
-	parsed, err := parseWorkspaceTokens(s.fs, s.cfg, nil, s.cwd)
+	cfg, cwd := s.configForRequest(ctx, sessionFromResourceReq(req))
+	parsed, err := parseWorkspaceTokens(s.fs, cfg, nil, cwd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tokens: %w", err)
 	}
@@ -123,18 +131,19 @@ func (s *Server) handleTokenSources(
 }
 
 func (s *Server) handleConfig(
-	_ context.Context,
+	ctx context.Context,
 	req *mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
 	if err := validateResourceRequest(req); err != nil {
 		return nil, err
 	}
 
+	cfg, _ := s.configForRequest(ctx, sessionFromResourceReq(req))
 	cfgData := map[string]any{
-		"prefix":    s.cfg.Prefix,
-		"schema":    s.cfg.Schema,
-		"files":     s.cfg.FilePaths(),
-		"resolvers": s.cfg.Resolvers,
+		"prefix":    cfg.Prefix,
+		"schema":    cfg.Schema,
+		"files":     cfg.FilePaths(),
+		"resolvers": cfg.Resolvers,
 	}
 
 	data, err := json.MarshalIndent(cfgData, "", "  ")
@@ -152,7 +161,7 @@ func (s *Server) handleConfig(
 }
 
 func (s *Server) handleTokensBySource(
-	_ context.Context,
+	ctx context.Context,
 	req *mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
 	if err := validateResourceRequest(req); err != nil {
@@ -165,7 +174,8 @@ func (s *Server) handleTokensBySource(
 		return nil, mcp.ResourceNotFoundError(req.Params.URI)
 	}
 
-	parsed, err := parseWorkspaceTokens(s.fs, s.cfg, nil, s.cwd)
+	cfg, cwd := s.configForRequest(ctx, sessionFromResourceReq(req))
+	parsed, err := parseWorkspaceTokens(s.fs, cfg, nil, cwd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tokens: %w", err)
 	}
@@ -196,7 +206,7 @@ func (s *Server) handleTokensBySource(
 }
 
 func (s *Server) handleTokenDetail(
-	_ context.Context,
+	ctx context.Context,
 	req *mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
 	if err := validateResourceRequest(req); err != nil {
@@ -209,7 +219,8 @@ func (s *Server) handleTokenDetail(
 		return nil, mcp.ResourceNotFoundError(req.Params.URI)
 	}
 
-	parsed, err := parseWorkspaceTokens(s.fs, s.cfg, nil, s.cwd)
+	cfg, cwd := s.configForRequest(ctx, sessionFromResourceReq(req))
+	parsed, err := parseWorkspaceTokens(s.fs, cfg, nil, cwd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tokens: %w", err)
 	}

--- a/mcp/roots_test.go
+++ b/mcp/roots_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2026 Benny Powers. All rights reserved.
+Use of this source code is governed by the GPLv3
+license that can be found in the LICENSE file.
+*/
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"bennypowers.dev/asimonim/internal/mapfs"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectFS creates a filesystem with a config and token file at /project,
+// simulating a project root with .config/design-tokens.yaml.
+func projectFS() *mapfs.MapFileSystem {
+	mfs := mapfs.New()
+	mfs.AddFile("/project/.config/design-tokens.yaml", "files:\n  - /project/tokens.json\n", 0644)
+	mfs.AddFile("/project/tokens.json", `{
+		"color": {
+			"primary": {
+				"$type": "color",
+				"$value": "#FF0000"
+			}
+		}
+	}`, 0644)
+	return mfs
+}
+
+// cwdFS creates a filesystem with config at /mycwd for fallback tests.
+func cwdFS() *mapfs.MapFileSystem {
+	mfs := mapfs.New()
+	mfs.AddFile("/mycwd/.config/design-tokens.yaml", "files:\n  - /mycwd/tokens.json\n", 0644)
+	mfs.AddFile("/mycwd/tokens.json", `{
+		"spacing": {
+			"small": {
+				"$type": "dimension",
+				"$value": "4px"
+			}
+		}
+	}`, 0644)
+	return mfs
+}
+
+func TestSearchDiscoversConfigFromRoots(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{
+		Query: "primary",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "expected search to succeed via roots discovery, got: %s", resultText(t, result))
+
+	var tokens []tokenSummary
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &tokens))
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, "color-primary", tokens[0].Name)
+}
+
+func TestValidateDiscoversConfigFromRoots(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	result, _, err := s.handleValidate(context.Background(), nil, validateInput{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "expected validate to succeed via roots discovery, got: %s", resultText(t, result))
+	assert.Contains(t, resultText(t, result), "1 tokens")
+}
+
+func TestConvertDiscoversConfigFromRoots(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	result, _, err := s.handleConvert(context.Background(), nil, convertInput{
+		Format: "css",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "expected convert to succeed via roots discovery, got: %s", resultText(t, result))
+	assert.Contains(t, resultText(t, result), "--color-primary")
+}
+
+func TestRootsFallbackToCwd(t *testing.T) {
+	mfs := cwdFS()
+	s := NewServer(mfs, nil, "/mycwd")
+
+	// listRoots returns empty (client doesn't support roots)
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return nil, nil
+	}
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{
+		Query: "small",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "expected fallback to cwd, got: %s", resultText(t, result))
+}
+
+func TestRootsUsesFirstRootOnly(t *testing.T) {
+	mfs := projectFS()
+	mfs.AddFile("/other/.config/design-tokens.yaml", "files:\n  - /other/tokens.json\n", 0644)
+	mfs.AddFile("/other/tokens.json", `{
+		"other": {
+			"token": {
+				"$type": "color",
+				"$value": "#000"
+			}
+		}
+	}`, 0644)
+
+	s := NewServer(mfs, nil, "/elsewhere")
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return []*mcp.Root{
+			{URI: "file:///project"},
+			{URI: "file:///other"},
+		}, nil
+	}
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{
+		Query: "primary",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var tokens []tokenSummary
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &tokens))
+	// color.primary from first root (/project), not "other.token" from /other
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, "color-primary", tokens[0].Name)
+}
+
+func TestConfigCachedAfterFirstResolution(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+
+	calls := 0
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		calls++
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	result1, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "primary"})
+	require.NoError(t, err)
+	assert.False(t, result1.IsError)
+
+	result2, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "primary"})
+	require.NoError(t, err)
+	assert.False(t, result2.IsError)
+
+	assert.Equal(t, 1, calls, "listRoots should be called only once (cached)")
+}
+
+func TestRootsErrorFallbackToCwd(t *testing.T) {
+	mfs := cwdFS()
+	s := NewServer(mfs, nil, "/mycwd")
+
+	// listRoots returns error (client disconnected, permission denied, etc.)
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return nil, fmt.Errorf("session error: client disconnected")
+	}
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{
+		Query: "small",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "expected fallback to cwd when listRoots errors, got: %s", resultText(t, result))
+}
+
+func TestRootsInvalidURIFallbackToCwd(t *testing.T) {
+	mfs := cwdFS()
+
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"non-file scheme", "http://example.com/project"},
+		{"empty path", "file://"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer(mfs, nil, "/mycwd")
+			s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+				return []*mcp.Root{{URI: tt.uri}}, nil
+			}
+
+			result, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "small"})
+			require.NoError(t, err)
+			assert.False(t, result.IsError, "should fall back to cwd for URI %q, got: %s", tt.uri, resultText(t, result))
+		})
+	}
+}
+
+func TestFileURIToPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr bool
+	}{
+		{"unix path", "file:///home/user/project", "/home/user/project", false},
+		{"windows drive letter", "file:///C:/Users/project", "C:/Users/project", false},
+		{"percent-encoded space", "file:///my%20project", "/my project", false},
+		{"non-file scheme", "http://example.com", "", true},
+		{"empty path", "file://", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fileURIToPath(tt.uri)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCrossHandlerCaching(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+
+	var calls int32
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		atomic.AddInt32(&calls, 1)
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	// Call different handlers in sequence
+	r1, _, err := s.handleValidate(context.Background(), nil, validateInput{})
+	require.NoError(t, err)
+	assert.False(t, r1.IsError)
+
+	r2, _, err := s.handleConvert(context.Background(), nil, convertInput{Format: "css"})
+	require.NoError(t, err)
+	assert.False(t, r2.IsError)
+
+	r3, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "primary"})
+	require.NoError(t, err)
+	assert.False(t, r3.IsError)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "listRoots should be called once across different handlers")
+}
+
+func TestConcurrentResolveConfig(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		// Simulate slow RPC
+		time.Sleep(10 * time.Millisecond)
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 20)
+	results := make([]*mcp.CallToolResult, 20)
+
+	for i := range 20 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			r, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "primary"})
+			errs[idx] = err
+			results[idx] = r
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := range 20 {
+		require.NoError(t, errs[i], "goroutine %d", i)
+		assert.False(t, results[i].IsError, "goroutine %d", i)
+	}
+}
+
+func TestResolveConfigDoesNotHoldMutexDuringListRoots(t *testing.T) {
+	mfs := projectFS()
+	s := NewServer(mfs, nil, "/elsewhere")
+
+	// listRoots blocks for 50ms, simulating slow RPC
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		time.Sleep(50 * time.Millisecond)
+		return []*mcp.Root{{URI: "file:///project"}}, nil
+	}
+
+	// First goroutine triggers lazy resolution (slow listRoots)
+	// Second goroutine should not block on mutex during the RPC wait
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		s.resolveConfig(context.Background())
+	}()
+
+	// Give first goroutine a head start
+	time.Sleep(5 * time.Millisecond)
+
+	go func() {
+		defer wg.Done()
+		s.resolveConfig(context.Background())
+	}()
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// If mutex held during RPC, both goroutines serialize: ~100ms total.
+	// If mutex released during RPC, second goroutine proceeds faster: ~50ms total.
+	// Use 80ms as threshold.
+	assert.Less(t, elapsed, 80*time.Millisecond,
+		"resolveConfig should not hold mutex during listRoots RPC (elapsed %v)", elapsed)
+}
+
+func TestRootsNilListRootsResult(t *testing.T) {
+	mfs := cwdFS()
+	s := NewServer(mfs, nil, "/mycwd")
+
+	// Simulate SDK returning nil result without error
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return nil, nil
+	}
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "small"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "nil listRoots result should fall back to cwd")
+}
+
+func TestRootsPercentEncodedURI(t *testing.T) {
+	mfs := mapfs.New()
+	mfs.AddFile("/my project/.config/design-tokens.yaml", "files:\n  - /my project/tokens.json\n", 0644)
+	mfs.AddFile("/my project/tokens.json", `{
+		"encoded": {
+			"token": {
+				"$type": "color",
+				"$value": "#123456"
+			}
+		}
+	}`, 0644)
+
+	s := NewServer(mfs, nil, "/elsewhere")
+	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
+		return []*mcp.Root{{URI: "file:///my%20project"}}, nil
+	}
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "token"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "percent-encoded URI should decode to correct path, got: %s", resultText(t, result))
+}
+
+func TestRootsNilListRootsFuncFallbackToCwd(t *testing.T) {
+	mfs := cwdFS()
+	// listRoots field is nil (no session captured yet, no test injection)
+	s := NewServer(mfs, nil, "/mycwd")
+
+	result, _, err := s.handleSearch(context.Background(), nil, searchInput{Query: "small"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "nil listRoots func should fall back to cwd")
+}

--- a/mcp/roots_test.go
+++ b/mcp/roots_test.go
@@ -219,6 +219,7 @@ func TestFileURIToPath(t *testing.T) {
 	}{
 		{"unix path", "file:///home/user/project", "/home/user/project", false},
 		{"windows drive letter", "file:///C:/Users/project", "C:/Users/project", false},
+		{"UNC path", "file://server/share/project", "//server/share/project", false},
 		{"percent-encoded space", "file:///my%20project", "/my project", false},
 		{"non-file scheme", "http://example.com", "", true},
 		{"empty path", "file://", "", true},
@@ -299,39 +300,47 @@ func TestResolveConfigDoesNotHoldMutexDuringListRoots(t *testing.T) {
 	mfs := projectFS()
 	s := NewServer(mfs, nil, "/elsewhere")
 
-	// listRoots blocks for 50ms, simulating slow RPC
+	firstCallStarted := make(chan struct{})
+	unblock := make(chan struct{})
+	var callCount atomic.Int32
+
 	s.listRoots = func(_ context.Context) ([]*mcp.Root, error) {
-		time.Sleep(50 * time.Millisecond)
+		n := callCount.Add(1)
+		if n == 1 {
+			close(firstCallStarted)
+			<-unblock
+		}
 		return []*mcp.Root{{URI: "file:///project"}}, nil
 	}
 
-	// First goroutine triggers lazy resolution (slow listRoots)
-	// Second goroutine should not block on mutex during the RPC wait
-	start := time.Now()
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	// Goroutine 1: enters resolveConfig, calls listRoots, blocks on unblock channel
 	go func() {
 		defer wg.Done()
 		s.resolveConfig(context.Background())
 	}()
 
-	// Give first goroutine a head start
-	time.Sleep(5 * time.Millisecond)
+	// Wait for first listRoots call to start (proving mutex was released)
+	<-firstCallStarted
 
+	// Goroutine 2: if mutex released during RPC, this enters listRoots concurrently
 	go func() {
 		defer wg.Done()
 		s.resolveConfig(context.Background())
 	}()
 
+	// Give goroutine 2 time to enter listRoots
+	time.Sleep(10 * time.Millisecond)
+
+	// Second call should have entered listRoots while first is blocked.
+	// If mutex were held during RPC, callCount would still be 1.
+	assert.GreaterOrEqual(t, callCount.Load(), int32(2),
+		"second resolveConfig should enter listRoots while first is blocked (mutex not held during RPC)")
+
+	close(unblock)
 	wg.Wait()
-	elapsed := time.Since(start)
-
-	// If mutex held during RPC, both goroutines serialize: ~100ms total.
-	// If mutex released during RPC, second goroutine proceeds faster: ~50ms total.
-	// Use 80ms as threshold.
-	assert.Less(t, elapsed, 80*time.Millisecond,
-		"resolveConfig should not hold mutex during listRoots RPC (elapsed %v)", elapsed)
 }
 
 func TestRootsNilListRootsResult(t *testing.T) {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -134,8 +134,11 @@ func (s *Server) ensureListRoots(session *mcp.ServerSession) {
 }
 
 // fileURIToPath converts a file:// URI to a filesystem path.
-// Handles Windows drive letters (file:///C:/path → C:/path)
-// and percent-encoded characters (file:///my%20dir → /my dir).
+// Handles:
+//   - Unix paths: file:///home/user → /home/user
+//   - Windows drive letters: file:///C:/path → C:/path
+//   - UNC paths: file://server/share/path → //server/share/path
+//   - Percent-encoded characters: file:///my%20dir → /my dir
 func fileURIToPath(uri string) (string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -145,6 +148,10 @@ func fileURIToPath(uri string) (string, error) {
 		return "", &url.Error{Op: "parse", URL: uri, Err: url.InvalidHostError(u.Scheme)}
 	}
 	path := u.Path
+	if u.Host != "" {
+		// UNC-style: file://server/share → //server/share
+		path = "//" + u.Host + path
+	}
 	if path == "" {
 		return "", &url.Error{Op: "parse", URL: uri, Err: url.InvalidHostError("empty path")}
 	}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -8,6 +8,8 @@ package mcp
 
 import (
 	"context"
+	"net/url"
+	"sync"
 
 	"bennypowers.dev/asimonim/config"
 	"bennypowers.dev/asimonim/fs"
@@ -18,12 +20,20 @@ import (
 // Server implements an MCP server for design tokens.
 type Server struct {
 	fs     fs.FileSystem
-	cfg    *config.Config
 	cwd    string
 	server *mcp.Server
+
+	// listRoots resolves project roots from the MCP client.
+	// Set automatically from session on first tool call; injectable for tests.
+	listRoots func(ctx context.Context) ([]*mcp.Root, error)
+
+	mu      sync.Mutex
+	rootDir string         // resolved lazily from roots, then cached
+	cfg     *config.Config // loaded lazily from rootDir, then cached
 }
 
 // NewServer creates a new design tokens MCP server.
+// If cfg is nil, config is resolved lazily from MCP roots on first use.
 func NewServer(filesystem fs.FileSystem, cfg *config.Config, cwd string) *Server {
 	s := &Server{
 		fs:  filesystem,
@@ -39,6 +49,110 @@ func NewServer(filesystem fs.FileSystem, cfg *config.Config, cwd string) *Server
 	s.setupResources()
 
 	return s
+}
+
+// configForRequest resolves config from the MCP session, caching the result.
+// Captures the session's ListRoots on first call, then resolves config lazily.
+func (s *Server) configForRequest(ctx context.Context, session *mcp.ServerSession) (*config.Config, string) {
+	if session != nil {
+		s.ensureListRoots(session)
+	}
+	return s.resolveConfig(ctx)
+}
+
+// resolveConfig returns the config, resolving it lazily from MCP roots if needed.
+// Uses double-check locking to avoid holding the mutex during the listRoots RPC.
+func (s *Server) resolveConfig(ctx context.Context) (*config.Config, string) {
+	s.mu.Lock()
+	if s.cfg != nil {
+		cfg, cwd := s.cfg, s.resolvedCwd()
+		s.mu.Unlock()
+		return cfg, cwd
+	}
+	listRoots := s.listRoots
+	s.mu.Unlock()
+
+	rootDir := s.resolveRootDir(ctx, listRoots)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cfg != nil {
+		return s.cfg, s.resolvedCwd()
+	}
+	s.rootDir = rootDir
+	s.cfg = config.LoadOrDefault(s.fs, rootDir)
+	return s.cfg, s.resolvedCwd()
+}
+
+// resolveRootDir determines the project root directory.
+// Tries MCP roots first (primary root), falls back to cwd.
+func (s *Server) resolveRootDir(ctx context.Context, listRoots func(context.Context) ([]*mcp.Root, error)) string {
+	if listRoots == nil {
+		return s.cwd
+	}
+
+	roots, err := listRoots(ctx)
+	if err != nil || len(roots) == 0 {
+		return s.cwd
+	}
+
+	path, err := fileURIToPath(roots[0].URI)
+	if err != nil {
+		return s.cwd
+	}
+
+	return path
+}
+
+// resolvedCwd returns the resolved project root, or cwd as fallback.
+// Must be called under s.mu.
+func (s *Server) resolvedCwd() string {
+	if s.rootDir != "" {
+		return s.rootDir
+	}
+	return s.cwd
+}
+
+// ensureListRoots captures the session's ListRoots for lazy config resolution.
+// No-op if listRoots is already set (e.g., by tests).
+func (s *Server) ensureListRoots(session *mcp.ServerSession) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.listRoots != nil || session == nil {
+		return
+	}
+	s.listRoots = func(ctx context.Context) ([]*mcp.Root, error) {
+		result, err := session.ListRoots(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			return nil, nil
+		}
+		return result.Roots, nil
+	}
+}
+
+// fileURIToPath converts a file:// URI to a filesystem path.
+// Handles Windows drive letters (file:///C:/path → C:/path)
+// and percent-encoded characters (file:///my%20dir → /my dir).
+func fileURIToPath(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "file" {
+		return "", &url.Error{Op: "parse", URL: uri, Err: url.InvalidHostError(u.Scheme)}
+	}
+	path := u.Path
+	if path == "" {
+		return "", &url.Error{Op: "parse", URL: uri, Err: url.InvalidHostError("empty path")}
+	}
+	// Handle Windows drive letters: /C:/path → C:/path
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return path, nil
 }
 
 // Run starts the MCP server with stdio transport.

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -115,11 +115,12 @@ func errorResult(text string) *mcp.CallToolResult {
 }
 
 func (s *Server) handleValidate(
-	_ context.Context,
-	_ *mcp.CallToolRequest,
+	ctx context.Context,
+	req *mcp.CallToolRequest,
 	input validateInput,
 ) (*mcp.CallToolResult, any, error) {
-	parsed, err := parseWorkspaceTokens(s.fs, s.cfg, input.Files, s.cwd)
+	cfg, cwd := s.configForRequest(ctx, sessionFromToolReq(req))
+	parsed, err := parseWorkspaceTokens(s.fs, cfg, input.Files, cwd)
 	if err != nil {
 		return errorResult(fmt.Sprintf("Validation error: %v", err)), nil, nil
 	}
@@ -170,8 +171,8 @@ func (s *Server) handleValidate(
 }
 
 func (s *Server) handleSearch(
-	_ context.Context,
-	_ *mcp.CallToolRequest,
+	ctx context.Context,
+	req *mcp.CallToolRequest,
 	input searchInput,
 ) (*mcp.CallToolResult, any, error) {
 	if input.Query == "" {
@@ -182,7 +183,8 @@ func (s *Server) handleSearch(
 		return errorResult("Error: name_only and value_only are mutually exclusive"), nil, nil
 	}
 
-	parsed, err := parseWorkspaceTokens(s.fs, s.cfg, nil, s.cwd)
+	cfg, cwd := s.configForRequest(ctx, sessionFromToolReq(req))
+	parsed, err := parseWorkspaceTokens(s.fs, cfg, nil, cwd)
 	if err != nil {
 		return errorResult(fmt.Sprintf("Error: %v", err)), nil, nil
 	}
@@ -234,8 +236,8 @@ func (s *Server) handleSearch(
 }
 
 func (s *Server) handleConvert(
-	_ context.Context,
-	_ *mcp.CallToolRequest,
+	ctx context.Context,
+	req *mcp.CallToolRequest,
 	input convertInput,
 ) (*mcp.CallToolResult, any, error) {
 	if input.Format == "" {
@@ -247,7 +249,8 @@ func (s *Server) handleConvert(
 		return errorResult(fmt.Sprintf("Error: %v", err)), nil, nil
 	}
 
-	parsed, err := parseWorkspaceTokens(s.fs, s.cfg, input.Files, s.cwd)
+	cfg, cwd := s.configForRequest(ctx, sessionFromToolReq(req))
+	parsed, err := parseWorkspaceTokens(s.fs, cfg, input.Files, cwd)
 	if err != nil {
 		return errorResult(fmt.Sprintf("Error: %v", err)), nil, nil
 	}
@@ -273,6 +276,13 @@ func (s *Server) handleConvert(
 	}
 
 	return textResult(string(output)), nil, nil
+}
+
+func sessionFromToolReq(req *mcp.CallToolRequest) *mcp.ServerSession {
+	if req == nil {
+		return nil
+	}
+	return req.Session
 }
 
 func matchString(s, query string, pattern *regexp.Regexp) bool {


### PR DESCRIPTION
## Summary

- MCP server now discovers `.config/design-tokens.yaml` from the MCP client's
  project root instead of the process's working directory
- Uses the MCP roots protocol to resolve the primary workspace root on first
  tool/resource call, with fallback to cwd
- Config is resolved lazily and cached after first resolution

## Problem

When Claude Code (or any MCP client) spawns `asimonim mcp`, the child process
inherits the parent's cwd, which may differ from the project root. The CLI
works because the user runs it from the project directory. The MCP server
loaded config eagerly from `"."` at startup, so it never found
`.config/design-tokens.yaml`.

## Changes

**`mcp/server.go`**
- Lazy config resolution via `resolveConfig()` with double-check locking
  (mutex released during the `listRoots` RPC to avoid blocking concurrent
  handlers)
- `fileURIToPath()` converts `file://` URIs to paths, handling Windows
  drive letters and percent-encoding
- `configForRequest()` extracts the repeated session-capture + config-resolve
  pattern into a single call
- `ensureListRoots()` captures the session's `ListRoots` capability on first
  request, with nil-result guard

**`mcp/tools.go`** / **`mcp/resources.go`**
- All 7 handlers use `configForRequest(ctx, session)` instead of direct
  field access, eliminating repeated boilerplate

**`cmd/mcp/mcp.go`**
- Removed eager `config.LoadOrDefault` at startup; passes nil config to
  `NewServer`

**`mcp/roots_test.go`** (new, 381 lines)
- Config discovery from roots (search, validate, convert)
- Fallback to cwd (empty roots, error from `listRoots`, nil func)
- First-root-only semantics with multi-root
- Config caching (single `listRoots` call across handlers)
- Cross-handler caching (validate, convert, search sequence)
- Concurrent access with race detector
- Mutex not held during RPC (timing-based regression test)
- `fileURIToPath` unit tests (unix, Windows drive letter, percent-encoding,
  error cases)
- Percent-encoded URI end-to-end

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `go test ./mcp/ -race` passes
- [ ] Manual: install updated binary, verify `search_tokens` discovers config
  from a project with `.config/design-tokens.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace roots now support dynamic configuration discovery.
  * Configuration is resolved per-request with fallback to the current working directory.

* **Tests**
  * Added comprehensive test suite for workspace roots configuration handling, including fallback behavior, caching, and concurrency validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bennypowers/asimonim/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->