### PR TITLE
refactor: migrate list, search, convert commands to load.LoadAll

### DIFF
--- a/cmd/convert/convert.go
+++ b/cmd/convert/convert.go
@@ -8,6 +8,7 @@ license that can be found in the LICENSE file.
 package convert
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,6 +24,7 @@ import (
 	convertlib "bennypowers.dev/asimonim/convert"
 	"bennypowers.dev/asimonim/convert/formatter"
 	"bennypowers.dev/asimonim/fs"
+	"bennypowers.dev/asimonim/load"
 	"bennypowers.dev/asimonim/parser"
 	"bennypowers.dev/asimonim/resolver"
 	"bennypowers.dev/asimonim/schema"
@@ -183,55 +185,16 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	filesystem := fs.NewOSFileSystem()
-	jsonParser := parser.NewJSONParser()
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
-	specResolver, err := specifier.NewDefaultResolver(filesystem, cwd)
-	if err != nil {
-		return fmt.Errorf("failed to create resolver: %w", err)
-	}
 
-	// Load config from .config/design-tokens.{yaml,json}
 	cfg := config.LoadOrDefault(filesystem, ".")
-
-	// Use config files if no args provided
-	var resolvedFiles []*specifier.ResolvedFile
-	if len(args) == 0 {
-		var err error
-		resolvedFiles, err = cfg.ResolveFiles(specResolver, filesystem, ".")
-		if err != nil {
-			return fmt.Errorf("error resolving config files: %w", err)
-		}
-
-		// Also resolve sources from resolver documents (not for in-place mode,
-		// which should only rewrite files explicitly listed in config)
-		if !inPlace && len(cfg.Resolvers) > 0 {
-			resolverSources, err := cfg.ResolveResolverSources(specResolver, filesystem, cwd)
-			if err != nil {
-				return fmt.Errorf("error resolving resolver sources: %w", err)
-			}
-			resolvedFiles = specifier.DedupResolvedFiles(append(resolvedFiles, resolverSources...))
-		}
-	} else {
-		for _, arg := range args {
-			rf, err := specResolver.Resolve(arg)
-			if err != nil {
-				return fmt.Errorf("error resolving %s: %w", arg, err)
-			}
-			resolvedFiles = append(resolvedFiles, rf)
-		}
-	}
-
-	if len(resolvedFiles) == 0 {
-		return fmt.Errorf("no files specified and no files found in config")
-	}
 
 	var targetSchema schema.Version
 	if schemaFlag != "" {
-		var err error
 		targetSchema, err = schema.FromString(schemaFlag)
 		if err != nil {
 			return fmt.Errorf("invalid schema version: %s", schemaFlag)
@@ -241,10 +204,41 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if inPlace {
+		jsonParser := parser.NewJSONParser()
+		specResolver, err := specifier.NewDefaultResolver(filesystem, cwd)
+		if err != nil {
+			return fmt.Errorf("failed to create resolver: %w", err)
+		}
+
+		var resolvedFiles []*specifier.ResolvedFile
+		if len(args) == 0 {
+			resolvedFiles, err = cfg.ResolveFiles(specResolver, filesystem, ".")
+			if err != nil {
+				return fmt.Errorf("error resolving config files: %w", err)
+			}
+		} else {
+			for _, arg := range args {
+				rf, err := specResolver.Resolve(arg)
+				if err != nil {
+					return fmt.Errorf("error resolving %s: %w", arg, err)
+				}
+				resolvedFiles = append(resolvedFiles, rf)
+			}
+		}
+		if len(resolvedFiles) == 0 {
+			return fmt.Errorf("no files specified and no files found in config")
+		}
 		return runInPlace(filesystem, jsonParser, cfg, resolvedFiles, targetSchema)
 	}
 
-	// Resolve header content
+	result, err := load.LoadAll(context.Background(), cfg, args, load.Options{
+		Root:          cwd,
+		SchemaVersion: targetSchema,
+	})
+	if err != nil {
+		return err
+	}
+
 	header, err := resolveHeader(filesystem, headerFlag, cfg.Header)
 	if err != nil {
 		return fmt.Errorf("error resolving header: %w", err)
@@ -252,16 +246,14 @@ func run(cmd *cobra.Command, args []string) error {
 
 	outputs := cliOutputs
 	if len(outputs) == 0 && len(cfg.Outputs) > 0 && output == "" {
-		// Use config outputs only if no single output is specified
 		outputs = cfg.Outputs
 	}
 
-	// Multi-output mode
 	if len(outputs) > 0 {
-		return runMultiOutput(filesystem, jsonParser, cfg, resolvedFiles, targetSchema, outputs, header, cssSelector, cssModule, snippetType, jsModule, jsTypes, jsExport)
+		return runMultiOutput(filesystem, cfg, result.All, result.Version, targetSchema, outputs, header, cssSelector, cssModule, snippetType, jsModule, jsTypes, jsExport)
 	}
 
-	return runCombined(filesystem, jsonParser, cfg, resolvedFiles, targetSchema, output, format, flatten, delimiter, header, cssSelector, cssModule, snippetType, jsModule, jsTypes, jsExport)
+	return runCombined(filesystem, cfg, result.All, result.Version, targetSchema, output, format, flatten, delimiter, header, cssSelector, cssModule, snippetType, jsModule, jsTypes, jsExport)
 }
 
 // resolveHeader resolves the header content from a flag value or config.
@@ -363,9 +355,9 @@ func runInPlace(
 
 func runCombined(
 	filesystem fs.FileSystem,
-	jsonParser *parser.JSONParser,
 	cfg *config.Config,
-	resolvedFiles []*specifier.ResolvedFile,
+	allTokens []*token.Token,
+	detectedVersion schema.Version,
 	targetSchema schema.Version,
 	output string,
 	format convertlib.Format,
@@ -379,13 +371,6 @@ func runCombined(
 	jsTypes string,
 	jsExport string,
 ) error {
-	// Parse all files and resolve aliases
-	allTokens, detectedVersion, err := parseAndResolveTokens(filesystem, jsonParser, cfg, resolvedFiles)
-	if err != nil {
-		return err
-	}
-
-	// Determine output schema
 	outputSchema := targetSchema
 	if outputSchema == schema.Unknown {
 		outputSchema = detectedVersion
@@ -442,9 +427,9 @@ var pathIndexPattern = regexp.MustCompile(`^path\[(\d+)\]$`)
 
 func runMultiOutput(
 	filesystem fs.FileSystem,
-	jsonParser *parser.JSONParser,
 	cfg *config.Config,
-	resolvedFiles []*specifier.ResolvedFile,
+	allTokens []*token.Token,
+	detectedVersion schema.Version,
 	targetSchema schema.Version,
 	outputs []config.OutputSpec,
 	header string,
@@ -455,13 +440,6 @@ func runMultiOutput(
 	jsTypes string,
 	jsExport string,
 ) error {
-	// Parse all files and resolve aliases
-	allTokens, detectedVersion, err := parseAndResolveTokens(filesystem, jsonParser, cfg, resolvedFiles)
-	if err != nil {
-		return err
-	}
-
-	// Determine output schema
 	outputSchema := targetSchema
 	if outputSchema == schema.Unknown {
 		outputSchema = detectedVersion
@@ -804,61 +782,3 @@ func ensureDir(filesystem fs.FileSystem, path string) error {
 	return filesystem.MkdirAll(dir, 0755)
 }
 
-// parseAndResolveTokens parses all files and resolves aliases.
-func parseAndResolveTokens(
-	filesystem fs.FileSystem,
-	jsonParser *parser.JSONParser,
-	cfg *config.Config,
-	resolvedFiles []*specifier.ResolvedFile,
-) ([]*token.Token, schema.Version, error) {
-	var allTokens []*token.Token
-	var detectedVersion schema.Version
-	var failures int
-
-	for _, rf := range resolvedFiles {
-		data, err := filesystem.ReadFile(rf.Path)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", rf.Specifier, err)
-			failures++
-			continue
-		}
-
-		version, err := schema.DetectVersion(data, nil)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error detecting schema for %s: %v\n", rf.Specifier, err)
-			failures++
-			continue
-		}
-		if detectedVersion == schema.Unknown {
-			detectedVersion = version
-		}
-
-		opts := cfg.OptionsForFile(rf.Specifier)
-		opts.SkipPositions = true
-		if version != schema.Unknown {
-			opts.SchemaVersion = version
-		}
-
-		tokens, err := jsonParser.ParseFile(filesystem, rf.Path, opts)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error parsing %s: %v\n", rf.Specifier, err)
-			failures++
-			continue
-		}
-
-		allTokens = append(allTokens, tokens...)
-	}
-
-	if len(allTokens) == 0 && failures > 0 {
-		return nil, schema.Unknown, fmt.Errorf("failed to parse %d file(s), no tokens generated", failures)
-	}
-
-	if detectedVersion == schema.Unknown {
-		detectedVersion = schema.Draft
-	}
-	if err := resolver.ResolveAliases(allTokens, detectedVersion); err != nil {
-		return nil, schema.Unknown, fmt.Errorf("error resolving aliases: %w", err)
-	}
-
-	return allTokens, detectedVersion, nil
-}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -8,6 +8,7 @@ license that can be found in the LICENSE file.
 package list
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"os"
@@ -19,10 +20,8 @@ import (
 	"bennypowers.dev/asimonim/cmd/render"
 	"bennypowers.dev/asimonim/config"
 	"bennypowers.dev/asimonim/fs"
-	"bennypowers.dev/asimonim/parser"
-	"bennypowers.dev/asimonim/resolver"
+	"bennypowers.dev/asimonim/load"
 	"bennypowers.dev/asimonim/schema"
-	"bennypowers.dev/asimonim/specifier"
 	"bennypowers.dev/asimonim/token"
 )
 
@@ -77,124 +76,52 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	filesystem := fs.NewOSFileSystem()
-	jsonParser := parser.NewJSONParser()
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
-	specResolver, err := specifier.NewDefaultResolver(filesystem, cwd)
-	if err != nil {
-		return fmt.Errorf("failed to create resolver: %w", err)
-	}
 
-	// Load config from .config/design-tokens.{yaml,json}
 	cfg := config.LoadOrDefault(filesystem, ".")
-
-	// Use config files if no args provided
-	var resolvedFiles []*specifier.ResolvedFile
-	if len(args) == 0 {
-		var err error
-		resolvedFiles, err = cfg.ResolveFiles(specResolver, filesystem, ".")
-		if err != nil {
-			return fmt.Errorf("error resolving config files: %w", err)
-		}
-
-		// Also resolve sources from resolver documents
-		if len(cfg.Resolvers) > 0 {
-			resolverSources, err := cfg.ResolveResolverSources(specResolver, filesystem, cwd)
-			if err != nil {
-				return fmt.Errorf("error resolving resolver sources: %w", err)
-			}
-			resolvedFiles = specifier.DedupResolvedFiles(append(resolvedFiles, resolverSources...))
-		}
-	} else {
-		for _, arg := range args {
-			rf, err := specResolver.Resolve(arg)
-			if err != nil {
-				return fmt.Errorf("error resolving %s: %w", arg, err)
-			}
-			resolvedFiles = append(resolvedFiles, rf)
-		}
-	}
-
-	if len(resolvedFiles) == 0 {
-		return fmt.Errorf("no files specified and no files found in config")
-	}
 
 	var schemaVersion schema.Version
 	if schemaFlag != "" {
-		var err error
 		schemaVersion, err = schema.FromString(schemaFlag)
 		if err != nil {
 			return fmt.Errorf("invalid schema version: %s", schemaFlag)
 		}
-	} else if cfg.SchemaVersion() != schema.Unknown {
-		schemaVersion = cfg.SchemaVersion()
 	}
 
-	var allTokens []*token.Token
-	var detectedVersion schema.Version
+	result, err := load.LoadAll(context.Background(), cfg, args, load.Options{
+		Root:          cwd,
+		SchemaVersion: schemaVersion,
+	})
+	if err != nil {
+		return err
+	}
+
+	allTokens := result.All
+
+	// Extract group metadata for markdown rendering
 	var allGroupMeta = make(map[string]render.GroupMeta)
-
-	// Phase 1: Parse all files
-	for _, rf := range resolvedFiles {
-		data, err := filesystem.ReadFile(rf.Path)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", rf.Specifier, err)
-			continue
-		}
-
-		// Extract group metadata for markdown rendering
-		if format == "markdown" || format == "md" {
-			if groupMeta, err := render.ExtractGroupMeta(data); err == nil {
+	if format == "markdown" || format == "md" {
+		for _, src := range result.Sources {
+			data, readErr := filesystem.ReadFile(src.Path)
+			if readErr != nil {
+				continue
+			}
+			if groupMeta, metaErr := render.ExtractGroupMeta(data); metaErr == nil {
 				maps.Copy(allGroupMeta, groupMeta)
 			}
 		}
-
-		version := schemaVersion
-		if version == schema.Unknown {
-			version, err = schema.DetectVersion(data, nil)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error detecting schema for %s: %v\n", rf.Specifier, err)
-				continue
-			}
-		}
-		if detectedVersion == schema.Unknown {
-			detectedVersion = version
-		}
-
-		// Get per-file options from config (use original specifier for matching)
-		opts := cfg.OptionsForFile(rf.Specifier)
-		opts.SkipPositions = true // CLI doesn't need LSP position tracking
-		if version != schema.Unknown {
-			opts.SchemaVersion = version
-		}
-		tokens, err := jsonParser.ParseFile(filesystem, rf.Path, opts)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error parsing %s: %v\n", rf.Specifier, err)
-			continue
-		}
-
-		allTokens = append(allTokens, tokens...)
 	}
 
-	// Phase 2: Resolve aliases across all tokens (enables cross-file references)
-	if detectedVersion == schema.Unknown {
-		detectedVersion = schema.Draft
-	}
-	if err := resolver.ResolveAliases(allTokens, detectedVersion); err != nil {
-		return fmt.Errorf("error resolving aliases: %w", err)
-	}
-
-	// Apply filters
 	allTokens = filterTokens(allTokens, typeFilter, groupFilter, onlyDeprecated, hideDeprecated)
 
 	sort.Slice(allTokens, func(i, j int) bool {
 		return allTokens[i].Name < allTokens[j].Name
 	})
 
-	// Compute display rows once
 	rows := render.ComputeRows(allTokens, resolved)
 
 	switch format {

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -8,6 +8,7 @@ license that can be found in the LICENSE file.
 package search
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"os"
@@ -20,9 +21,8 @@ import (
 	"bennypowers.dev/asimonim/cmd/render"
 	"bennypowers.dev/asimonim/config"
 	"bennypowers.dev/asimonim/fs"
-	"bennypowers.dev/asimonim/parser"
+	"bennypowers.dev/asimonim/load"
 	"bennypowers.dev/asimonim/schema"
-	"bennypowers.dev/asimonim/specifier"
 	"bennypowers.dev/asimonim/token"
 )
 
@@ -87,50 +87,13 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	filesystem := fs.NewOSFileSystem()
-	jsonParser := parser.NewJSONParser()
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
-	specResolver, err := specifier.NewDefaultResolver(filesystem, cwd)
-	if err != nil {
-		return fmt.Errorf("failed to create resolver: %w", err)
-	}
 
-	// Load config from .config/design-tokens.{yaml,json}
 	cfg := config.LoadOrDefault(filesystem, ".")
-
-	// Use config files if no files provided
-	var resolvedFiles []*specifier.ResolvedFile
-	if len(files) == 0 {
-		var err error
-		resolvedFiles, err = cfg.ResolveFiles(specResolver, filesystem, ".")
-		if err != nil {
-			return fmt.Errorf("error resolving config files: %w", err)
-		}
-
-		// Also resolve sources from resolver documents
-		if len(cfg.Resolvers) > 0 {
-			resolverSources, err := cfg.ResolveResolverSources(specResolver, filesystem, cwd)
-			if err != nil {
-				return fmt.Errorf("error resolving resolver sources: %w", err)
-			}
-			resolvedFiles = specifier.DedupResolvedFiles(append(resolvedFiles, resolverSources...))
-		}
-	} else {
-		for _, file := range files {
-			rf, err := specResolver.Resolve(file)
-			if err != nil {
-				return fmt.Errorf("error resolving %s: %w", file, err)
-			}
-			resolvedFiles = append(resolvedFiles, rf)
-		}
-	}
-
-	if len(resolvedFiles) == 0 {
-		return fmt.Errorf("no files specified and no files found in config")
-	}
 
 	var schemaVersion schema.Version
 	if schemaFlag != "" {
@@ -138,75 +101,56 @@ func run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid schema version: %s", schemaFlag)
 		}
-	} else if cfg.SchemaVersion() != schema.Unknown {
-		schemaVersion = cfg.SchemaVersion()
 	}
 
-	var matches []*token.Token
+	result, err := load.LoadAll(context.Background(), cfg, files, load.Options{
+		Root:          cwd,
+		SchemaVersion: schemaVersion,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Extract group metadata for markdown rendering
 	var allGroupMeta = make(map[string]render.GroupMeta)
-
-	for _, rf := range resolvedFiles {
-		data, err := filesystem.ReadFile(rf.Path)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", rf.Specifier, err)
-			continue
-		}
-
-		// Extract group metadata for markdown rendering
-		if format == "markdown" || format == "md" {
-			if groupMeta, err := render.ExtractGroupMeta(data); err == nil {
+	if format == "markdown" || format == "md" {
+		for _, src := range result.Sources {
+			data, readErr := filesystem.ReadFile(src.Path)
+			if readErr != nil {
+				continue
+			}
+			if groupMeta, metaErr := render.ExtractGroupMeta(data); metaErr == nil {
 				maps.Copy(allGroupMeta, groupMeta)
 			}
 		}
+	}
 
-		version := schemaVersion
-		if version == schema.Unknown {
-			version, err = schema.DetectVersion(data, nil)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error detecting schema for %s: %v\n", rf.Specifier, err)
-				continue
-			}
+	// Search across all loaded tokens
+	var matches []*token.Token
+	for _, tok := range result.All {
+		matched := false
+		if nameOnly {
+			matched = matchString(tok.Name, query, pattern)
+		} else if valueOnly {
+			matched = matchString(tok.Value, query, pattern)
+		} else {
+			matched = matchString(tok.Name, query, pattern) ||
+				matchString(tok.Value, query, pattern) ||
+				matchString(tok.Type, query, pattern) ||
+				matchString(tok.Description, query, pattern)
 		}
 
-		// Get per-file options from config (use original specifier for matching)
-		opts := cfg.OptionsForFile(rf.Specifier)
-		opts.SkipPositions = true // CLI doesn't need LSP position tracking
-		if version != schema.Unknown {
-			opts.SchemaVersion = version
-		}
-		tokens, err := jsonParser.ParseFile(filesystem, rf.Path, opts)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error parsing %s: %v\n", rf.Specifier, err)
-			continue
-		}
-
-		for _, tok := range tokens {
-			matched := false
-			if nameOnly {
-				matched = matchString(tok.Name, query, pattern)
-			} else if valueOnly {
-				matched = matchString(tok.Value, query, pattern)
-			} else {
-				matched = matchString(tok.Name, query, pattern) ||
-					matchString(tok.Value, query, pattern) ||
-					matchString(tok.Type, query, pattern) ||
-					matchString(tok.Description, query, pattern)
-			}
-
-			if matched {
-				matches = append(matches, tok)
-			}
+		if matched {
+			matches = append(matches, tok)
 		}
 	}
 
-	// Apply filters
 	matches = filterTokens(matches, typeFilter, groupFilter, onlyDeprecated, hideDeprecated)
 
 	sort.Slice(matches, func(i, j int) bool {
 		return matches[i].Name < matches[j].Name
 	})
 
-	// Compute display rows
 	rows := render.ComputeRows(matches, false)
 
 	switch format {

--- a/load/load.go
+++ b/load/load.go
@@ -209,6 +209,7 @@ func Load(ctx context.Context, spec string, opts Options) (*token.Map, error) {
 // SourceTokens holds tokens grouped by their originating source.
 type SourceTokens struct {
 	Source string
+	Path   string
 	Tokens []*token.Token
 }
 
@@ -321,6 +322,7 @@ func LoadAll(ctx context.Context, cfg *config.Config, files []string, opts Optio
 
 		result.Sources = append(result.Sources, SourceTokens{
 			Source: rf.Specifier,
+			Path:   path,
 			Tokens: tokens,
 		})
 		allTokens = append(allTokens, tokens...)


### PR DESCRIPTION
## Summary

- Migrate list, search, and convert CLI commands to use `load.LoadAll()` instead of inline file resolution + parse + alias resolution
- Delete `parseAndResolveTokens` helper from convert (now redundant)
- Add `Path` field to `load.SourceTokens` so callers can re-read raw bytes (needed for markdown group metadata extraction)
- Net -207 lines of duplicated orchestration code

## Details

**list/search**: Replace ~40-line resolution+parse+alias blocks with a single `load.LoadAll()` call. Group metadata for markdown mode extracted post-load by re-reading files from `result.Sources[].Path`.

**convert**: Replace resolution block and `parseAndResolveTokens` helper with `load.LoadAll()` for combined and multi-output modes. In-place mode keeps its own resolution (no resolver sources, per-file schema handling).

**validate**: Unchanged. Per-file validation (cycle detection, per-file alias resolution, deprecated counting) is incompatible with LoadAll's bulk approach.

**Behavioral change**: Old code used soft failure (stderr + continue) on per-file parse errors. LoadAll fails fast on first error. This is intentional: partial results from silently skipped files are worse than a clear error message.

## Test plan

- [x] `make lint` and `make test` pass (all existing tests)
- [x] Manual: `asimonim list testdata/fixtures/draft/simple/tokens.json`
- [x] Manual: `asimonim search color testdata/fixtures/draft/simple/tokens.json`
- [x] Manual: `asimonim convert --format css testdata/fixtures/draft/simple/tokens.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal token-loading pipeline across convert, list, and search commands for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->